### PR TITLE
Update get_next_line.c

### DIFF
--- a/libft/get_next_line/get_next_line.c
+++ b/libft/get_next_line/get_next_line.c
@@ -3,99 +3,105 @@
 /*                                                        :::      ::::::::   */
 /*   get_next_line.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: efinda <marvin@42.fr>                      +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/05/30 20:57:28 by efinda            #+#    #+#             */
-/*   Updated: 2024/05/30 20:57:32 by efinda           ###   ########.fr       */
+/*   Updated by: efinda (Enhanced version)             +#+  +:+       +#+        */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../libft.h"
 
-static	char	*one_line(char *str)
+/*
+ * extract_line:
+ *   Allocates and returns a new string containing the next line from s.
+ *   The returned line includes the newline character if found.
+ *   Returns NULL if s is NULL or empty.
+ */
+static char	*extract_line(const char *s)
 {
 	int		i;
-	int		j;
-	char	*new_line;
+	char	*line;
 
+	if (!s || *s == '\0')
+		return (NULL);
 	i = 0;
-	j = 0;
-	if (!str || *str == '\0')
-		return (NULL);
-	while (str[i] && str[i] != '\n')
+	while (s[i] && s[i] != '\n')
 		i++;
-	if (str[i] == '\n')
-		i++;
-	new_line = (char *)malloc(sizeof(char) * (i + 1));
-	if (!new_line)
+	if (s[i] == '\n')
+		i++;  // Include the newline character.
+	line = (char *)malloc(sizeof(char) * (i + 1));
+	if (!line)
 		return (NULL);
-	while (j < i)
-	{
-		new_line[j] = str[j];
-		j++;
-	}
-	new_line[j] = '\0';
-	return (new_line);
+	// Copy i+1 characters (including the terminating '\0')
+	ft_strlcpy(line, s, i + 1);
+	return (line);
 }
 
-static	char	*ft_substr_gnl(char *str, int start, int end)
+/*
+ * remove_extracted_line:
+ *   Given the buffer s and the length (len) of the extracted line,
+ *   allocates a new string containing the remainder of s and frees s.
+ *   Returns NULL if there is no remainder.
+ */
+static char	*remove_extracted_line(char *s, int len)
 {
-	char	*res;
-	int		i;
-	int		dif;
+	int		total_len;
+	char	*new_buf;
 
-	i = 0;
-	dif = end - start;
-	if (dif == 0 || !str)
+	if (!s)
+		return (NULL);
+	total_len = ft_strlen(s);
+	if (len >= total_len)
 	{
-		ft_strfree(&str);
+		free(s);
 		return (NULL);
 	}
-	res = (char *)malloc(sizeof(char) * (dif + 1));
-	if (!res)
-		return (NULL);
-	while (str[start])
-	{
-		res[i] = str[start];
-		i++;
-		start++;
-	}
-	res[i] = '\0';
-	ft_strfree(&str);
-	return (res);
+	new_buf = ft_substr(s, len, total_len - len);
+	free(s);
+	return (new_buf);
 }
 
-static	void	gnl_free(char *str, char *buffer)
-{
-	ft_strfree(&str);
-	ft_strfree(&buffer);
-}
-
+/*
+ * get_next_line:
+ *   Reads from file descriptor fd until a newline is found (or EOF),
+ *   returning the next line as a newly allocated string.
+ *   Uses a static array to hold leftover data between calls.
+ */
 char	*get_next_line(int fd)
 {
-	static char	*str[FD_MAX];
-	char		*buffer;
+	static char	*fd_buffer[FD_MAX];
+	char		*temp;
+	char		*line;
 	int			bytes_read;
 
-	bytes_read = 1;
 	if (fd < 0 || BUFFER_SIZE <= 0)
 		return (NULL);
-	buffer = (char *)malloc(sizeof(char) * (BUFFER_SIZE + 1));
-	if (!buffer)
+	// Allocate temporary buffer for reading.
+	temp = (char *)malloc(sizeof(char) * (BUFFER_SIZE + 1));
+	if (!temp)
 		return (NULL);
-	while (bytes_read && !ft_strchr(str[fd], '\n'))
+	bytes_read = 1;
+	// Read until a newline is encountered or no more bytes are read.
+	while (bytes_read > 0 && !ft_strchr(fd_buffer[fd], '\n'))
 	{
-		bytes_read = read(fd, buffer, BUFFER_SIZE);
+		bytes_read = read(fd, temp, BUFFER_SIZE);
 		if (bytes_read == -1)
 		{
-			gnl_free(str[fd], buffer);
+			free(temp);
+			if (fd_buffer[fd])
+			{
+				free(fd_buffer[fd]);
+				fd_buffer[fd] = NULL;
+			}
 			return (NULL);
 		}
-		buffer[bytes_read] = '\0';
-		str[fd] = ft_strjoin_free(str[fd], buffer);
+		temp[bytes_read] = '\0';
+		// Append the newly read data to fd_buffer[fd].
+		fd_buffer[fd] = ft_strjoin_free(fd_buffer[fd], temp);
 	}
-	ft_strfree(&buffer);
-	buffer = one_line(str[fd]);
-	str[fd] = ft_substr_gnl(str[fd], ft_strlen(buffer), ft_strlen(str[fd]));
-	return (buffer);
+	free(temp);
+	// Extract the next line from the buffer.
+	line = extract_line(fd_buffer[fd]);
+	// Update the buffer by removing the extracted line.
+	if (line)
+		fd_buffer[fd] = remove_extracted_line(fd_buffer[fd], ft_strlen(line));
+	return (line);
 }


### PR DESCRIPTION
• Clearer function names:
 – extract_line() now returns the next line (including the newline, if present).  – remove_extracted_line() removes the extracted portion from the saved buffer.

• Robust error checking and memory management:
 – Allocations and reads are checked carefully.
 – The static buffer is freed when appropriate.

• Simplified logic and comments:
 – The main loop now ensures that the buffer is concatenated safely using a helper function (ft_strjoin_free, assumed to free the previous pointer).  – We use standard functions like ft_strlen and ft_strchr (from your libft).

Make sure that your libft provides (or you implement) the helper functions (ft_strjoin_free, ft_strlen, ft_strchr, ft_substr, and ft_strlcpy or an equivalent) as used below.

Explanation of Enhancements
Function Renaming & Documentation:
The functions are now more self-explanatory with comments describing their purpose.

Improved Buffer Management:
The static array fd_buffer stores leftover data from previous reads. When a line is extracted, the remainder is computed and saved for future calls.

Robust Error Handling:
If a read fails, the temporary buffer and any allocated fd_buffer for that fd are freed.

Modular Design:
The use of helper functions makes the code easier to test and maintain. You can further tweak behaviors (such as how the newline is handled) in one place.

This refined implementation should be easier to understand, maintain, and integrate with your libft.